### PR TITLE
Add RUN_DAILY env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ LOG_LEVEL=INFO
 # The title for the summary message
 # Default: Customer Channel Summary
 SUMMARY_TITLE=Customer Channel Summary
+
+# Run Daily
+# Set to "true" to run every day, "false" to skip weekends
+RUN_DAILY=true

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ python test_setup.py
 | `IGNORE_CHANNELS` | Comma-separated channel IDs to skip | `C1234567890,C0987654321` |
 | `SUMMARY_TITLE` | Title for summary messages (optional) | `Customer Channel Summary` |
 | `LOG_LEVEL` | Logging level (optional) | `INFO` |
+| `RUN_DAILY` | Run every day (`true`) or skip weekends (`false`) | `true` |
 
 ### Bot Settings
 
-In `slack_summary_bot.py`:
-- `RUN_DAILY`: Set to `True` for daily runs, `False` to skip weekends
+In `.env`:
+- `RUN_DAILY`: Set to `true` for daily runs, `false` to skip weekends
 
 ## Usage
 

--- a/slack_summary_bot.py
+++ b/slack_summary_bot.py
@@ -21,7 +21,7 @@ IGNORE_CHANNELS = (
 )
 SUMMARY_TITLE = os.getenv("SUMMARY_TITLE", "Customer Channel Summary")
 
-RUN_DAILY = True  # Set to True for daily runs, False to skip weekends
+RUN_DAILY = os.getenv("RUN_DAILY", "true").lower() == "true"
 
 # Setup logging
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()


### PR DESCRIPTION
## Summary
- add environment variable `RUN_DAILY` in `slack_summary_bot.py`
- document `RUN_DAILY` in README
- show how to configure `RUN_DAILY` in `.env.example`

## Testing
- `black --check --diff .`
- `python -c "import slack_summary_bot"`

Flake8 could not be installed due to environment limitations.

------
https://chatgpt.com/codex/tasks/task_e_688672398ff88332b81b352114ffc672