### PR TITLE
Add basic unit tests for Slack summary functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ slackinsights/
 ```bash
 python -m pytest tests/
 ```
+All unit tests are stored in the `tests/` directory.
 
 ## Contributing
 

--- a/test_setup.py
+++ b/test_setup.py
@@ -16,7 +16,7 @@ from openai import AsyncOpenAI
 load_dotenv()
 
 
-async def test_slack_connection():
+async def check_slack_connection():
     """Test Slack API connection and permissions."""
     print("🔍 Testing Slack connection...")
 
@@ -81,7 +81,7 @@ async def test_slack_connection():
         return False
 
 
-async def test_openai_connection():
+async def check_openai_connection():
     """Test OpenAI API connection."""
     print("\n🔍 Testing OpenAI connection...")
 
@@ -160,8 +160,8 @@ async def main():
         sys.exit(1)
 
     # Test connections
-    slack_ok = await test_slack_connection()
-    openai_ok = await test_openai_connection()
+    slack_ok = await check_slack_connection()
+    openai_ok = await check_openai_connection()
 
     # Summary
     print("\n" + "=" * 50)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+import slack_summary_bot as bot
+
+
+def test_format_messages():
+    messages = [
+        {"type": "message", "user": "U1", "text": "Hello", "ts": "100"},
+        {"type": "message", "user": "U2", "subtype": "bot_message", "text": "Bot", "ts": "101"},
+        {"type": "message", "user": "BOT", "text": "skip", "ts": "102"},
+        {"type": "message", "user": "U3", "text": "Thread", "ts": "103", "thread_ts": "103"},
+        {"type": "message", "user": "U4", "text": "Reply", "ts": "104", "thread_ts": "103"},
+        {"type": "file_share", "user": "U5", "text": "file", "ts": "105"},
+    ]
+    formatted = bot.format_messages(messages, "BOT")
+    assert formatted == [
+        {"user": "U1", "text": "Hello", "ts": "100", "thread_ts": ""},
+        {"user": "U3", "text": "Thread", "ts": "103", "thread_ts": "103"},
+        {"user": "U4", "text": "Reply", "ts": "104", "thread_ts": "103"},
+    ]
+
+
+def test_update_message_list():
+    message_list = [
+        {"user": "U1", "text": "Hi", "ts": "100"},
+        {"user": "U2", "text": "Parent", "ts": "101", "thread_ts": "101"},
+        {"user": "U3", "text": "Later", "ts": "106"},
+    ]
+    threaded = [
+        {"user": "U4", "text": "R1", "ts": "103"},
+        {"user": "U5", "text": "R0", "ts": "102"},
+    ]
+    result = bot.update_message_list(message_list[:], threaded, "101")
+    assert [m["ts"] for m in result] == [
+        "100",
+        "101",
+        "102",
+        "103",
+        "106",
+    ]
+
+
+class FixedDateTime(datetime):
+    fixed_now = datetime(2024, 4, 8, 12, 0, 0)
+
+    @classmethod
+    def now(cls):
+        return cls.fixed_now
+
+
+def test_get_time_range_daily(monkeypatch):
+    monkeypatch.setattr(bot, "RUN_DAILY", True)
+    monkeypatch.setattr(bot, "datetime", FixedDateTime)
+    start, end = bot.get_time_range()
+    assert end == FixedDateTime.fixed_now
+    assert start == FixedDateTime.fixed_now - bot.timedelta(days=1)
+
+
+def test_get_time_range_weekend_skip(monkeypatch):
+    weekend = FixedDateTime.fixed_now
+    weekend = weekend - bot.timedelta(days=weekend.weekday() - 5)  # set to Saturday
+    class WeekEndDT(FixedDateTime):
+        fixed_now = weekend
+    monkeypatch.setattr(bot, "RUN_DAILY", False)
+    monkeypatch.setattr(bot, "datetime", WeekEndDT)
+    start, end = bot.get_time_range()
+    assert start is None and end is None
+
+
+def test_get_time_range_weekstart(monkeypatch):
+    monday = FixedDateTime.fixed_now
+    monday = monday - bot.timedelta(days=monday.weekday())  # set to Monday
+    class MondayDT(FixedDateTime):
+        fixed_now = monday
+    monkeypatch.setattr(bot, "RUN_DAILY", False)
+    monkeypatch.setattr(bot, "datetime", MondayDT)
+    start, end = bot.get_time_range()
+    assert end == monday
+    assert start == monday - bot.timedelta(days=3)
+


### PR DESCRIPTION
## Summary
- add tests directory with new unit tests
- ensure setup script isn't picked up by pytest
- mention tests directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688676a69fd48332b6a22cb60e2eb755